### PR TITLE
Upgrade to new jenkins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,13 @@
     </dependencies>
   </dependencyManagement>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+    </dependency>
+  </dependencies>
+
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/copyarchiver-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/copyarchiver-plugin.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -5,19 +6,20 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.406</version>
-    <relativePath></relativePath>
+    <version>4.16</version>
+    <relativePath/>
   </parent>
 
   <artifactId>copyarchiver</artifactId>
   <version>0.5.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
-
   <name>Jenkins Copy Archiver Plug-in</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin</url>
+
   <licenses>
     <license>
-      <name>MIT license</name>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
       <comments>All source code is under the MIT license.</comments>
     </license>
   </licenses>
@@ -35,56 +37,39 @@
     </developer>
   </developers>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.277.x</artifactId>
+        <version>26</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/copyarchiver-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/copyarchiver-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/copyarchiver-plugin</url>
+    <url>https://github.com/jenkinsci/copyarchiver-plugin</url>
   </scm>
-  <distributionManagement>
-    <repository>
-      <id>maven.jenkins-ci.org</id>
-      <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-    </repository>
-  </distributionManagement>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <jenkins.version>2.277.1</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
-  <dependencies>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>maven-plugin</artifactId>
-    </dependency>
-  </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <configuration>
-          <disabledTestInjection>true</disabledTestInjection>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>
-
-

--- a/src/main/java/com/thalesgroup/hudson/plugins/copyarchiver/CopyArchiverPublisher.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/copyarchiver/CopyArchiverPublisher.java
@@ -36,6 +36,7 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
+import jenkins.MasterToSlaveFileCallable;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -225,7 +226,7 @@ public class CopyArchiverPublisher extends Notifier implements Serializable {
 
                 final FilePath destDirFilePath = new FilePath(new File(filterField(build, listener, sharedDirectoryPath)));
                 final boolean isMatrixExcutorProject = MatrixConfiguration.class.isAssignableFrom(project.getClass());
-                Boolean result = build.getWorkspace().act(new FilePath.FileCallable<Boolean>() {
+                Boolean result = build.getWorkspace().act(new MasterToSlaveFileCallable<Boolean>() {
                     public Boolean invoke(File f, VirtualChannel channel) throws IOException {
 
                         try {

--- a/src/main/java/com/thalesgroup/hudson/plugins/copyarchiver/FilePathArchiver.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/copyarchiver/FilePathArchiver.java
@@ -32,6 +32,7 @@ import hudson.remoting.Future;
 import hudson.remoting.Pipe;
 import hudson.remoting.VirtualChannel;
 import hudson.util.IOException2;
+import jenkins.MasterToSlaveFileCallable;
 import org.apache.commons.io.IOUtils;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
@@ -77,7 +78,7 @@ public class FilePathArchiver implements Serializable {
     public int copyRecursiveTo(final boolean flatten, final String fileMask, final String excludes, final FilePath target) throws IOException, InterruptedException {
         if (filePath.getChannel() == target.getChannel()) {
             // local to local copy.
-            return filePath.act(new FileCallable<Integer>() {
+            return filePath.act(new MasterToSlaveFileCallable<Integer>() {
                 public Integer invoke(File base, VirtualChannel channel) throws IOException {
                     if (!base.exists()) return 0;
                     assert target.getChannel() == null;
@@ -104,7 +105,7 @@ public class FilePathArchiver implements Serializable {
 
             //final FilePath targetTemp = new FilePath(Util.createTempDir());
 
-            Future<Integer> future = filePath.actAsync(new FileCallable<Integer>() {
+            Future<Integer> future = filePath.actAsync(new MasterToSlaveFileCallable<Integer>() {
                 public Integer invoke(File f, VirtualChannel channel) throws IOException {
                     try {
                         return writeToTar(f, fileMask, excludes, TarCompression.GZIP.compress(pipe.getOut()));

--- a/src/main/resources/com/thalesgroup/hudson/plugins/copyarchiver/CopyArchiverPublisher/config.jelly
+++ b/src/main/resources/com/thalesgroup/hudson/plugins/copyarchiver/CopyArchiverPublisher/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
 /*******************************************************************************
 * Copyright (c) 2009 Thales Corporate Services SAS                             *

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
 /*******************************************************************************
 * Copyright (c) 2009 Thales Corporate Services SAS                             *


### PR DESCRIPTION
We use this plugin to copy the artifact to a directory (nfs mounted).
This patches upgrade the code for build with new jenkins (tested with 2.289.3)